### PR TITLE
fix(sec): upgrade bottle to 0.12.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ slack-sdk>=3.4.0
 peewee>=3.14.10
 PyMySQL>=1.0.2
 distro>=1.2.0
-bottle>=0.12.18
+bottle>=0.12.20
 psutil>=5.9.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in bottle 0.12.18
- [CVE-2020-28473](https://www.oscs1024.com/hd/CVE-2020-28473)


### What did I do？
Upgrade bottle from 0.12.18 to 0.12.20 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS